### PR TITLE
feat: モーションセンサー情報を取得するAirPodsMotionServiceクラスを追加

### DIFF
--- a/lib/actons/get-gyro.dart
+++ b/lib/actons/get-gyro.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_airpods/flutter_airpods.dart';
+import 'package:flutter_airpods/models/attitude.dart';
+import 'package:flutter_airpods/models/rotation_rate.dart';
+import 'package:flutter_airpods/models/device_motion_data.dart';
+
+/// AirPodsのモーションセンサー情報にアクセスするためのユーティリティクラス。
+class AirPodsMotionService {
+  // インスタンス化を禁止（staticメソッド専用）
+  const AirPodsMotionService._();
+
+  // デバイスモーションのストリーム（内部保持用）
+  static final Stream<DeviceMotionData> _motionStream =
+      FlutterAirpods.getAirPodsDeviceMotionUpdates.asBroadcastStream();
+
+  /// 現在のジャイロ値と姿勢（クォータニオン）を同時に取得する。
+  ///
+  /// このメソッドはAirPodsから最新のデバイスモーションデータを取得し、
+  /// ジャイロ値と姿勢を返します。
+  ///
+  /// 戻り値:
+  ///   [Map]<[String], [dynamic]> - 'gyro'キーにジャイロ値、'attitude'キーに姿勢（クォータニオン）を持つマップ。
+  static Future<Map<String, dynamic>> getCurrentMotion() async {
+    final DeviceMotionData data = await _motionStream.first;
+    return {'gyro': data.rotationRate, 'attitude': data.attitude};
+  }
+
+  /// ジャイロ値のストリームを返す。
+  ///
+  /// 戻り値:
+  ///   [Stream]<[RotationRate]> - x, y, z の角速度を持つストリーム。
+  static Stream<RotationRate> gyroStream() =>
+      _motionStream.map((event) => event.rotationRate);
+
+  /// 姿勢（クォータニオン）のストリームを返す。
+  ///
+  /// 戻り値:
+  ///   [Stream]<[Attitude]> - x, y, z, wのクォータニオンと、ピッチ、ロール、ヨー角度を持つストリーム。
+  static Stream<Attitude> attitudeStream() =>
+      _motionStream.map((event) => event.attitude);
+}

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_airpods/models/attitude.dart';
+import 'package:flutter_airpods/models/rotation_rate.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:nekoze_notify/actons/get-gyro.dart';
 import 'package:nekoze_notify/main.dart';
 import 'package:nekoze_notify/screen/personalize_screen.dart';
 
@@ -13,6 +16,11 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
   Future<void> _showPostureNotification() async {
     const DarwinNotificationDetails iosDetails = DarwinNotificationDetails(
       presentAlert: true,
@@ -65,6 +73,40 @@ class _HomeScreenState extends State<HomeScreen> {
                 _showPostureNotification();
               },
               child: Text('通知を出す'),
+            ),
+            Center(
+              child: StreamBuilder<RotationRate>(
+                stream: AirPodsMotionService.gyroStream(),
+                builder: (
+                  BuildContext context,
+                  AsyncSnapshot<RotationRate> snapshot,
+                ) {
+                  if (snapshot.hasData) {
+                    return Text(
+                      "x: ${snapshot.data!.x},\n y: ${snapshot.data!.y},\n z: ${snapshot.data!.z}",
+                    );
+                  } else {
+                    return const Text("AirPodsが接続されていません。");
+                  }
+                },
+              ),
+            ),
+            Center(
+              child: StreamBuilder<Attitude>(
+                stream: AirPodsMotionService.attitudeStream(),
+                builder: (
+                  BuildContext context,
+                  AsyncSnapshot<Attitude> snapshot,
+                ) {
+                  if (snapshot.hasData) {
+                    return Text(
+                      "pitch: ${snapshot.data!.pitch},\n roll: ${snapshot.data!.roll},\n yaw: ${snapshot.data!.yaw}",
+                    );
+                  } else {
+                    return const Text("AirPodsが接続されていません。");
+                  }
+                },
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
## 概要
AirPodsモーションセンサー情報を取得するために、ユーティリティクラスAirPodsMotionServiceを追加。

## 実装
 - AirPodsMotionServiceを追加

## 備考