### PR TITLE
use threshold of roll and pitch

### DIFF
--- a/lib/screen/debug_screen.dart
+++ b/lib/screen/debug_screen.dart
@@ -19,6 +19,8 @@ class _DebugScreenState extends State<DebugScreen> {
 
   PostureState _currentPostureState = PostureState.good;
   double _currentPitch = 0.0;
+  double _currentRoll = 0.0;
+  double _currentYaw = 0.0;
   double? _baselinePitch;
   double _pitchDifference = 0.0;
   bool _isAnalyzing = false;
@@ -95,6 +97,8 @@ class _DebugScreenState extends State<DebugScreen> {
 
         setState(() {
           _currentPitch = attitude.pitch.toDouble();
+          _currentRoll = attitude.roll.toDouble();
+          _currentYaw = attitude.yaw.toDouble();
           _pitchDifference = _baselinePitch != null ? (_baselinePitch! - _currentPitch) : 0.0;
 
           // Simulate the notification logic from PostureAnalyzer
@@ -248,6 +252,10 @@ class _DebugScreenState extends State<DebugScreen> {
                       ),
                       const SizedBox(height: 8),
                       Text('現在のピッチ値: ${_currentPitch.toStringAsFixed(4)} rad'),
+                      const SizedBox(height: 8),
+                      Text('現在のロール値: ${_currentRoll.toStringAsFixed(4)} rad'),
+                      const SizedBox(height: 8),
+                      Text('現在のヨー値: ${_currentYaw.toStringAsFixed(4)} rad'),
                       const SizedBox(height: 8),
                       Text('基準ピッチ値: ${_baselinePitch?.toStringAsFixed(4) ?? "未設定"} rad'),
                       const SizedBox(height: 8),


### PR DESCRIPTION
#22 に対してrollとyaw情報を用いて閾値を設定し、それを超えたサンプルのpitch情報を0置換している。
なぜかrollとyawが閾値を超えた場合でもうまくワークしない（プログラムにバグがある）。

今回は移動平均ではなくHampelを用いている。
理由として、瞬間的な異常なデータを取り除く際にどうしてもサンプリング周波数の都合で閾値をギリギリ超えない部分のデータを拾うことがあるので、その場合の影響を緩和するためです。